### PR TITLE
Feature/username-db-add Adds backend capability for providing usernames to users. 

### DIFF
--- a/flask-discord/flaskd/__init__.py
+++ b/flask-discord/flaskd/__init__.py
@@ -26,9 +26,12 @@ def create_app(test_config=None):
     # Register db connection with app
     from . import db
     db.init_app(app)
-    
-    
+        
     @app.route("/")
+    def index():
+        sql_db = db.get_db()
+
+    @app.route("/login")
     def login():
         return render_template('login_1.html')
     

--- a/flask-discord/flaskd/__init__.py
+++ b/flask-discord/flaskd/__init__.py
@@ -26,10 +26,13 @@ def create_app(test_config=None):
     # Register db connection with app
     from . import db
     db.init_app(app)
-        
+
+    from . import auth
+    
     @app.route("/")
     def index():
-        sql_db = db.get_db()
+        auth.load_logged_in_user()
+        return render_template('index.html')
 
     @app.route("/login")
     def login():

--- a/flask-discord/flaskd/__init__.py
+++ b/flask-discord/flaskd/__init__.py
@@ -34,8 +34,9 @@ def create_app(test_config=None):
     @app.route("/")
     @auth.login_required
     def index():
-        #print(g.user)
-        return render_template('index.html')
+        username = g.user["username"] # Grabs username from database fetch stored in g upon user request of the page
+                                      # Stored in auth.py
+        return render_template('index.html',username=username)
 
     @app.route("/login")
     def login():

--- a/flask-discord/flaskd/__init__.py
+++ b/flask-discord/flaskd/__init__.py
@@ -27,11 +27,14 @@ def create_app(test_config=None):
     from . import db
     db.init_app(app)
 
+
     from . import auth
-    
+    app.register_blueprint(auth.bp)
+
     @app.route("/")
+    @auth.login_required
     def index():
-        auth.load_logged_in_user()
+        #print(g.user)
         return render_template('index.html')
 
     @app.route("/login")

--- a/flask-discord/flaskd/auth.py
+++ b/flask-discord/flaskd/auth.py
@@ -1,12 +1,12 @@
 import functools
 
-from Flask import ( 
+from flask import ( 
         Blueprint, flash, g, redirect, render_template, request, session, url_for
         )
 
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from flaskr.db import get_db
+from flaskd.db import get_db
 
 bp = Blueprint('auth',__name__,url_prefix='/auth')
 
@@ -22,3 +22,12 @@ def load_logged_in_user():
                 'SELECT * FROM user WHERE id = ?', (user_id,)
                 ).fetchone() # Grabs all columns in the user table where user_id is found. Load this in the session
 
+def login_required(view):
+    @functools.wraps(view)
+    def wrapped_view(**kwargs):
+        if g.user is None:
+            return redirect(url_for('login_1'))
+        
+        return view(**kwargs)
+    
+    return wrapped_view

--- a/flask-discord/flaskd/auth.py
+++ b/flask-discord/flaskd/auth.py
@@ -26,7 +26,7 @@ def login_required(view):
     @functools.wraps(view)
     def wrapped_view(**kwargs):
         if g.user is None:
-            return redirect(url_for('login_1'))
+            return redirect(url_for('login'))
         
         return view(**kwargs)
     

--- a/flask-discord/flaskd/auth.py
+++ b/flask-discord/flaskd/auth.py
@@ -1,0 +1,14 @@
+import functools
+
+from Flask import ( 
+        Blueprint, flash, g, redirect, render_template, request, session, url_for
+        )
+
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from flaskr.db import get_db
+
+bp = Blueprint('auth',__name__,url_prefix='/auth')
+
+
+

--- a/flask-discord/flaskd/auth.py
+++ b/flask-discord/flaskd/auth.py
@@ -11,4 +11,14 @@ from flaskr.db import get_db
 bp = Blueprint('auth',__name__,url_prefix='/auth')
 
 
+@bp.before_app_request
+def load_logged_in_user():
+    user_id = session.get('user_id')
+    
+    if user_id is None:
+        g.user = None
+    else:
+        g.user = get_db().execute(
+                'SELECT * FROM user WHERE id = ?', (user_id,)
+                ).fetchone() # Grabs all columns in the user table where user_id is found. Load this in the session
 

--- a/flask-discord/flaskd/schema.sql
+++ b/flask-discord/flaskd/schema.sql
@@ -4,7 +4,8 @@ DROP TABLE IF EXISTS siteViews;
 
 CREATE TABLE user (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
-	username TEXT UNIQUE NOT NULL,
+	email TEXT UNIQUE NOT NULL,
+	username TEXT NOT NULL DEFAULT "myspace Tom" CHECK( length(username) <= 32),
 	password TEXT NOT NULL
 );
 


### PR DESCRIPTION
Features:
- Adds email column to sql table (schema.sql) that can be used as login instead of user. This allows the user to change their username at will, but not their email.
  - The username cannot be longer than 32 characters long. Inserting a username was tested. The character limit works.
  - This feature breaks the current html login for registering the username. It should be changed to "email". 
- Added `auth.py` file containing authentication files for requiring login before viewing the index and loading the user information from the database into `g.user`. 
  - `g.user` can then be used to grab the username once the user is loads the index page after login. 
- Registered the auth.py file blueprint in the `__init__.py` file. This allows the code to be modular. Different packages dedicated to different parts of the web application.
- `auth.py` function `load_logged_in_user` loads the user information before any http request regardless of where the view function is called in the code. 